### PR TITLE
Fixed bug in _unixtime(date)

### DIFF
--- a/fhub/utils.py
+++ b/fhub/utils.py
@@ -154,4 +154,4 @@ def _normalize_date(date):
 
 def _unixtime(date):
     assert isinstance(date, str)
-    return datetime.strptime(_normalize_date(date), "%Y-%m-%d").strftime("%s")
+    return datetime.strptime(_normalize_date(date), "%Y-%m-%d").timestamp()


### PR DESCRIPTION
Use .timestamp() instead of .strftime('%s') .
See the comments of this answer https://stackoverflow.com/a/41811725/940974 .